### PR TITLE
Suggestions remi patch1

### DIFF
--- a/code.py
+++ b/code.py
@@ -135,12 +135,12 @@ leds.write_config(0)
 #
 # STEMMA QT Rotary encoder setup
 rotary_seesaw = seesaw.Seesaw(i2c, addr=0x36)  # default address is 0x36
-encoder1 = rotaryio.IncrementalEncoder(rotary_seesaw)
-last_encoder1_pos = 0
+tempo_encoder = rotaryio.IncrementalEncoder(rotary_seesaw)
+last_tempo_encoder_pos = 0
 rotary_seesaw.pin_mode(24, rotary_seesaw.INPUT_PULLUP)  # setup the button pin
 knobbutton_in = digitalio.DigitalIO(rotary_seesaw, 24)  # use seesaw digitalio
 knobbutton = Debouncer(knobbutton_in)  # create debouncer object for button
-encoder1_pos = -encoder1.position
+tempo_encoder_pos = -tempo_encoder.position
 
 
 # setup adafruit quad encoder
@@ -149,19 +149,19 @@ encoders = [adafruit_seesaw.rotaryio.IncrementalEncoder(seesaw, n) for n in rang
 rotary_seesaw2 = seesaw.Seesaw(i2c, addr=0x49)  # default address is 0x36
    
 # Pattern Length Encoder
-encoder2 = rotaryio.IncrementalEncoder(rotary_seesaw2, 1)
-    if encoder2_pos != last_encoder2_pos:
-        encoder2_delta = encoder2_pos - last_encoder2_pos
+pattern_length_encoder = rotaryio.IncrementalEncoder(rotary_seesaw2, 1)
+    if pattern_length_encoder_pos != last_pattern_length_encoder_pos:
+        pattern_length_encoder_delta = pattern_length_encoder_pos - last_pattern_length_encoder_pos
         adjust_range_length
-        last_encoder2_pos = encoder2_pos
+        last_pattern_length_encoder_pos = pattern_length_encoder_pos
 
 
 # Step Shift Encoder
-encoder3 = rotaryio.IncrementalEncoder(rotary_seesaw2, 3)
-    if encoder3_pos != last_encoder3_pos:
-        encoder3_delta = encoder3_pos - last_encoder3_pos
+step_shift_encoder = rotaryio.IncrementalEncoder(rotary_seesaw2, 3)
+    if step_shift_encoder_pos != last_step_shift_encoder_pos:
+        step_shift_encoder_delta = step_shift_encoder_pos - last_step_shift_encoder_pos
         adjust_range_start
-        last_encoder3_pos = encoder3_pos
+        last_step_shift_encoder_pos = step_shift_encoder_pos
 
 
 # MIDI setup
@@ -311,9 +311,9 @@ while True:
                     play_drum(drum.note)
             # TODO: how to display the current step? Separate LED?
             stepper.advance_step()
-            encoder1_pos = -encoder1.position  # only check encoder while playing between steps
+            tempo_encoder_pos = -tempo_encoder.position  # only check encoder while playing between steps
     else:  # check the encoder all the time when not playing
-        encoder1_pos = -encoder1.position
+        tempo_encoder_pos = -tempo_encoder.position
 
     # switches add or remove steps
     switch = switches.events.get()
@@ -328,14 +328,14 @@ while True:
             light_steps(drum_index, step_index, drum.sequence[step_index])  # toggle light
             leds.write()
 
-    if encoder1_pos != last_encoder1_pos:
-        encoder1_delta = encoder1_pos - last_encoder1_pos
+    if tempo_encoder_pos != last_tempo_encoder_pos:
+        tempo_encoder_delta = tempo_encoder_pos - last_tempo_encoder_pos
         newbpm = bpm + encoder_delta  # or (encoder_delta * 5)
         newbpm = min(max(newbpm, 10), 400)
         set_bpm(newbpm)
         display.fill(0)
         display.print(bpm)
-        last_encoder1_pos = encoder1_pos
+        last_tempo_encoder_pos = tempo_encoder_pos
 
 
 

--- a/code.py
+++ b/code.py
@@ -144,8 +144,6 @@ tempo_encoder_pos = -tempo_encoder.position
 
 
 # setup adafruit quad encoder
-encoders = [adafruit_seesaw.rotaryio.IncrementalEncoder(seesaw, n) for n in range(4)]
-
 rotary_seesaw2 = seesaw.Seesaw(i2c, addr=0x49)  # default address is 0x36
    
 # Pattern Length Encoder

--- a/code.py
+++ b/code.py
@@ -55,7 +55,7 @@ class stepper:
         # keep adjustment in the range where self.first_step >= 0 and
         # self.last_step < self.num_steps
         adjustment = max(adjustment, -self.first_step)
-        adjustment = min(adjustment, self.last_step - 1 - self.first_step)
+        adjustment = min(adjustment, self.num_steps - 1 - self.last_step)
         self.first_step += adjustment
         self.last_step += adjustment
         # TODO: self.current_step might be out of range; leave that
@@ -66,7 +66,7 @@ class stepper:
         # keep adjustment in the range where self.first_step <= self.last_step and
         # self.last_step < self.num_steps
         adjustment = max(adjustment, self.first_step - self.last_step)
-        adjustment = min(adjustment, self.last_step - 1 - self.first_step)
+        adjustment = min(adjustment, self.num_steps - 1 - self.last_step)
         self.last_step += adjustment
          # TODO: self.current_step might be out of range; leave that
         # as is; advance_step() will move it into the right range

--- a/code.py
+++ b/code.py
@@ -135,12 +135,34 @@ leds.write_config(0)
 #
 # STEMMA QT Rotary encoder setup
 rotary_seesaw = seesaw.Seesaw(i2c, addr=0x36)  # default address is 0x36
-encoder = rotaryio.IncrementalEncoder(rotary_seesaw)
-last_encoder_pos = 0
+encoder1 = rotaryio.IncrementalEncoder(rotary_seesaw)
+last_encoder1_pos = 0
 rotary_seesaw.pin_mode(24, rotary_seesaw.INPUT_PULLUP)  # setup the button pin
 knobbutton_in = digitalio.DigitalIO(rotary_seesaw, 24)  # use seesaw digitalio
 knobbutton = Debouncer(knobbutton_in)  # create debouncer object for button
-encoder_pos = -encoder.position
+encoder1_pos = -encoder1.position
+
+
+# setup adafruit quad encoder
+encoders = [adafruit_seesaw.rotaryio.IncrementalEncoder(seesaw, n) for n in range(4)]
+
+rotary_seesaw2 = seesaw.Seesaw(i2c, addr=0x49)  # default address is 0x36
+   
+# Pattern Length Encoder
+encoder2 = rotaryio.IncrementalEncoder(rotary_seesaw2, 1)
+    if encoder2_pos != last_encoder2_pos:
+        encoder2_delta = encoder2_pos - last_encoder2_pos
+        adjust_range_length
+        last_encoder2_pos = encoder2_pos
+
+
+# Step Shift Encoder
+encoder3 = rotaryio.IncrementalEncoder(rotary_seesaw2, 3)
+    if encoder3_pos != last_encoder3_pos:
+        encoder3_delta = encoder3_pos - last_encoder3_pos
+        adjust_range_start
+        last_encoder3_pos = encoder3_pos
+
 
 # MIDI setup
 midi = usb_midi.ports[1]
@@ -289,9 +311,9 @@ while True:
                     play_drum(drum.note)
             # TODO: how to display the current step? Separate LED?
             stepper.advance_step()
-            encoder_pos = -encoder.position  # only check encoder while playing between steps
+            encoder1_pos = -encoder1.position  # only check encoder while playing between steps
     else:  # check the encoder all the time when not playing
-        encoder_pos = -encoder.position
+        encoder1_pos = -encoder1.position
 
     # switches add or remove steps
     switch = switches.events.get()
@@ -306,14 +328,17 @@ while True:
             light_steps(drum_index, step_index, drum.sequence[step_index])  # toggle light
             leds.write()
 
-    if encoder_pos != last_encoder_pos:
-        encoder_delta = encoder_pos - last_encoder_pos
+    if encoder1_pos != last_encoder1_pos:
+        encoder1_delta = encoder1_pos - last_encoder1_pos
         newbpm = bpm + encoder_delta  # or (encoder_delta * 5)
         newbpm = min(max(newbpm, 10), 400)
         set_bpm(newbpm)
         display.fill(0)
         display.print(bpm)
-        last_encoder_pos = encoder_pos
+        last_encoder1_pos = encoder1_pos
+
+
+
 
  # suppresions:
  # type: ignore

--- a/code.py
+++ b/code.py
@@ -339,12 +339,12 @@ while True:
 
     if pattern_length_encoder_pos != last_pattern_length_encoder_pos:
         pattern_length_encoder_delta = pattern_length_encoder_pos - last_pattern_length_encoder_pos
-        adjust_range_length
+        stepper.adjust_range_length(pattern_length_encoder_delta)
         last_pattern_length_encoder_pos = pattern_length_encoder_pos
 
     if step_shift_encoder_pos != last_step_shift_encoder_pos:
         step_shift_encoder_delta = step_shift_encoder_pos - last_step_shift_encoder_pos
-        adjust_range_start
+        stepper.adjust_range_start(step_shift_encoder_delta)
         last_step_shift_encoder_pos = step_shift_encoder_pos
 
 

--- a/code.py
+++ b/code.py
@@ -152,20 +152,12 @@ rotary_seesaw2 = seesaw.Seesaw(i2c, addr=0x49)  # default address is 0x36
 pattern_length_encoder = rotaryio.IncrementalEncoder(rotary_seesaw2, 1)
 last_pattern_length_encoder_pos = 0
 pattern_length_encoder_pos = -pattern_length_encoder.position
-    if pattern_length_encoder_pos != last_pattern_length_encoder_pos:
-        pattern_length_encoder_delta = pattern_length_encoder_pos - last_pattern_length_encoder_pos
-        adjust_range_length
-        last_pattern_length_encoder_pos = pattern_length_encoder_pos
 
 
 # Step Shift Encoder
 step_shift_encoder = rotaryio.IncrementalEncoder(rotary_seesaw2, 3)
 last_step_shift_encoder_pos = 0
 step_shift_encoder_pos = -step_shift_encoder.position
-    if step_shift_encoder_pos != last_step_shift_encoder_pos:
-        step_shift_encoder_delta = step_shift_encoder_pos - last_step_shift_encoder_pos
-        adjust_range_start
-        last_step_shift_encoder_pos = step_shift_encoder_pos
 
 
 # MIDI setup
@@ -341,6 +333,15 @@ while True:
         display.print(bpm)
         last_tempo_encoder_pos = tempo_encoder_pos
 
+    if pattern_length_encoder_pos != last_pattern_length_encoder_pos:
+        pattern_length_encoder_delta = pattern_length_encoder_pos - last_pattern_length_encoder_pos
+        adjust_range_length
+        last_pattern_length_encoder_pos = pattern_length_encoder_pos
+
+    if step_shift_encoder_pos != last_step_shift_encoder_pos:
+        step_shift_encoder_delta = step_shift_encoder_pos - last_step_shift_encoder_pos
+        adjust_range_start
+        last_step_shift_encoder_pos = step_shift_encoder_pos
 
 
 

--- a/code.py
+++ b/code.py
@@ -150,6 +150,8 @@ rotary_seesaw2 = seesaw.Seesaw(i2c, addr=0x49)  # default address is 0x36
    
 # Pattern Length Encoder
 pattern_length_encoder = rotaryio.IncrementalEncoder(rotary_seesaw2, 1)
+last_pattern_length_encoder_pos = 0
+pattern_length_encoder_pos = -pattern_length_encoder.position
     if pattern_length_encoder_pos != last_pattern_length_encoder_pos:
         pattern_length_encoder_delta = pattern_length_encoder_pos - last_pattern_length_encoder_pos
         adjust_range_length
@@ -158,6 +160,8 @@ pattern_length_encoder = rotaryio.IncrementalEncoder(rotary_seesaw2, 1)
 
 # Step Shift Encoder
 step_shift_encoder = rotaryio.IncrementalEncoder(rotary_seesaw2, 3)
+last_step_shift_encoder_pos = 0
+step_shift_encoder_pos = -step_shift_encoder.position
     if step_shift_encoder_pos != last_step_shift_encoder_pos:
         step_shift_encoder_delta = step_shift_encoder_pos - last_step_shift_encoder_pos
         adjust_range_start

--- a/code.py
+++ b/code.py
@@ -308,8 +308,12 @@ while True:
             # TODO: how to display the current step? Separate LED?
             stepper.advance_step()
             tempo_encoder_pos = -tempo_encoder.position  # only check encoder while playing between steps
+            pattern_length_encoder_pos = -pattern_length_encoder.position
+            step_shift_encoder_pos = -step_shift_encoder.position
     else:  # check the encoder all the time when not playing
         tempo_encoder_pos = -tempo_encoder.position
+        pattern_length_encoder_pos = -pattern_length_encoder.position
+        step_shift_encoder_pos = -step_shift_encoder.position
 
     # switches add or remove steps
     switch = switches.events.get()


### PR DESCRIPTION
Here's what I suggested in Discord:

* [0332a11](https://github.com/aseanwatson/RP2040DrumSequencer/commit/0332a11): more meaningful encoder names
* [ffe304f](https://github.com/aseanwatson/RP2040DrumSequencer/commit/ffe304f): make last_X_encoder_pos/X_encoder_pos variables   
* [5ccd030](https://github.com/aseanwatson/RP2040DrumSequencer/commit/5ccd030): Move blocks to handle encoders down to main loop  
* [6518eff](https://github.com/aseanwatson/RP2040DrumSequencer/commit/6518eff): Follow temo_encoder_pos pattern for new encoders  
* [4814565](https://github.com/aseanwatson/RP2040DrumSequencer/commit/4814565): fix syntax for calls to adjust_range_length/adjust_range_start

Just remember that I don't have a way to test any of this ;-)